### PR TITLE
fix: check if win and buf is valid before interacting with them

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The default configuration is:
     "lsp"  -- LSP status updates
   },
   notify = {
-    clear_time = 5000, -- Time in milisecond before removing a vim.notifiy notification, 0 to make them sticky
+    clear_time = 5000, -- Time in milliseconds before removing a vim.notify notification, 0 to make them sticky
     min_level = vim.log.levels.INFO, -- Minimum log level to print the notification
   },
   component_name_recall = false -- Whether to prefix the title of the notification by the component name
@@ -53,7 +53,7 @@ title: string -- The title for this notification
 icon: string -- The icon for this notification, must be of display width 1 (see strdisplaywidth())
 ```
 
-## Acknoledgement
+## Acknowledgement
 
 Heavily inspired by [fidget.nvim]
 

--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -37,8 +37,8 @@ local function get_status_width()
 end
 
 function StatusModule._create_win()
-   if not StatusModule.win_nr or not vim.api.nvim_win_is_valid(StatusModule.win_nr) then
-      if not StatusModule.buf_nr or not vim.api.nvim_buf_is_valid(StatusModule.buf_nr) then
+   if not StatusModule.win_nr or not api.nvim_win_is_valid(StatusModule.win_nr) then
+      if not StatusModule.buf_nr or not api.nvim_buf_is_valid(StatusModule.buf_nr) then
          StatusModule.buf_nr = api.nvim_create_buf(false, true);
       end
       StatusModule.win_nr = api.nvim_open_win(StatusModule.buf_nr, false, {
@@ -59,7 +59,9 @@ function StatusModule._create_win()
 end
 
 function StatusModule._delete_win()
-   api.nvim_win_close(StatusModule.win_nr, true)
+   if StatusModule.win_nr and api.nvim_win_is_valid(StatusModule.win_nr) then
+      api.nvim_win_close(StatusModule.win_nr, true)
+   end
    StatusModule.win_nr = nil
 end
 

--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -37,8 +37,8 @@ local function get_status_width()
 end
 
 function StatusModule._create_win()
-   if not StatusModule.win_nr then
-      if not StatusModule.buf_nr then
+   if not StatusModule.win_nr or not vim.api.nvim_win_is_valid(StatusModule.win_nr) then
+      if not StatusModule.buf_nr or not vim.api.nvim_buf_is_valid(StatusModule.buf_nr) then
          StatusModule.buf_nr = api.nvim_create_buf(false, true);
       end
       StatusModule.win_nr = api.nvim_open_win(StatusModule.buf_nr, false, {

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -37,8 +37,8 @@ local function get_status_width(): integer
 end
 
 function StatusModule._create_win()
-  if not StatusModule.win_nr or not vim.api.nvim_win_is_valid(StatusModule.win_nr) then
-    if not StatusModule.buf_nr or not vim.api.nvim_buf_is_valid(StatusModule.buf_nr) then
+  if not StatusModule.win_nr or not api.nvim_win_is_valid(StatusModule.win_nr) then
+    if not StatusModule.buf_nr or not api.nvim_buf_is_valid(StatusModule.buf_nr) then
       StatusModule.buf_nr = api.nvim_create_buf(false, true);
     end
     StatusModule.win_nr = api.nvim_open_win(StatusModule.buf_nr, false, {
@@ -59,7 +59,9 @@ function StatusModule._create_win()
 end
 
 function StatusModule._delete_win()
-  api.nvim_win_close(StatusModule.win_nr, true)
+  if StatusModule.win_nr and api.nvim_win_is_valid(StatusModule.win_nr) then
+    api.nvim_win_close(StatusModule.win_nr, true)
+  end
   StatusModule.win_nr = nil
 end
 

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -37,8 +37,8 @@ local function get_status_width(): integer
 end
 
 function StatusModule._create_win()
-  if not StatusModule.win_nr then
-    if not StatusModule.buf_nr then
+  if not StatusModule.win_nr or not vim.api.nvim_win_is_valid(StatusModule.win_nr) then
+    if not StatusModule.buf_nr or not vim.api.nvim_buf_is_valid(StatusModule.buf_nr) then
       StatusModule.buf_nr = api.nvim_create_buf(false, true);
     end
     StatusModule.win_nr = api.nvim_open_win(StatusModule.buf_nr, false, {

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -52,18 +52,20 @@ global record vim
       nested: boolean|nil
     end
 
-    nvim_create_augroup: function(string, CreateAugroupOptions)
-    nvim_create_autocmd: function(string|{string}, CreateAutocmdOptions)
-    nvim_create_user_command: function(string, function(), CreateUserCommandOptions)
-    nvim_buf_set_lines: function(BufNr, integer, integer, boolean, {string})
     nvim_buf_add_highlight: function(BufNr, NSId, string, integer, integer, integer)
     nvim_buf_clear_namespace: function(BufNr, NSId, integer, integer)
-    nvim_open_win: function(BufNr, boolean, OpenWinOptions): WinNr
-    nvim_win_close: function(WinNr, boolean)
-    nvim_win_set_height: function(WinNr, integer)
+    nvim_buf_is_valid: function(BufNr): boolean
+    nvim_buf_set_lines: function(BufNr, integer, integer, boolean, {string})
+    nvim_create_augroup: function(string, CreateAugroupOptions)
+    nvim_create_autocmd: function(string|{string}, CreateAutocmdOptions)
     nvim_create_buf: function(boolean, boolean): BufNr
     nvim_create_namespace: function(string): NSId
+    nvim_create_user_command: function(string, function(), CreateUserCommandOptions)
+    nvim_open_win: function(BufNr, boolean, OpenWinOptions): WinNr
     nvim_set_hl: function(NSId, string, SetHlOptions)
+    nvim_win_close: function(WinNr, boolean)
+    nvim_win_is_valid: function(WinNr): boolean
+    nvim_win_set_height: function(WinNr, integer)
     nvim_win_set_hl_ns: function(WinNr, NSId)
   end
 


### PR DESCRIPTION
This fixes the issue where the `win_nr` and `buf_nr` fields may refer to
a window and buffer that no longer are valid (e.g., been closed or
wiped).
