### PR TITLE
fix: increase zindex to be greater than satellite.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The default configuration is:
     clear_time = 5000, -- Time in milliseconds before removing a vim.notify notification, 0 to make them sticky
     min_level = vim.log.levels.INFO, -- Minimum log level to print the notification
   },
-  component_name_recall = false -- Whether to prefix the title of the notification by the component name
+  component_name_recall = false, -- Whether to prefix the title of the notification by the component name
+  zindex = 50, -- The zindex to use for the floating window. Note that changing this value may cause visual bugs with other windows overlapping the notifier window.
 }
 ```
 

--- a/lua/notifier/config.lua
+++ b/lua/notifier/config.lua
@@ -29,6 +29,8 @@ local ConfigModule = {Config = {Notify = {}, }, }
 
 
 
+
+
 ConfigModule.NS_NAME = "Notifier"
 ConfigModule.NS_ID = vim.api.nvim_create_namespace("notifier")
 
@@ -50,6 +52,7 @@ ConfigModule.config = {
    },
    component_name_recall = false,
    debug = false,
+   zindex = 50,
 }
 
 function ConfigModule.update(other)

--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -62,7 +62,7 @@ function StatusModule._create_win()
          height = 3,
          row = vim.o.lines - vim.o.cmdheight - 1,
          col = vim.o.columns,
-         zindex = 10,
+         zindex = 50,
       })
       if api.nvim_win_set_hl_ns then
          api.nvim_win_set_hl_ns(StatusModule.win_nr, cfg.NS_ID)

--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -62,7 +62,7 @@ function StatusModule._create_win()
          height = 3,
          row = vim.o.lines - vim.o.cmdheight - 1,
          col = vim.o.columns,
-         zindex = 50,
+         zindex = cfg.config.zindex,
       })
       if api.nvim_win_set_hl_ns then
          api.nvim_win_set_hl_ns(StatusModule.win_nr, cfg.NS_ID)

--- a/teal/notifier/config.tl
+++ b/teal/notifier/config.tl
@@ -12,6 +12,8 @@ local record ConfigModule
 
     -- For... debug purposes
     debug: boolean
+
+    zindex: integer
   end
 
   config: Config
@@ -50,6 +52,7 @@ ConfigModule.config = {
   } as ConfigModule.Config.Notify,
   component_name_recall = false,
   debug = false,
+  zindex = 50,
 }
 
 function ConfigModule.update(other: ConfigModule.Config)

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -62,7 +62,7 @@ function StatusModule._create_win()
       height = 3,
       row = vim.o.lines - vim.o.cmdheight - 1,
       col = vim.o.columns,
-      zindex = 50,
+      zindex = cfg.config.zindex,
     })
     if api.nvim_win_set_hl_ns then
       api.nvim_win_set_hl_ns(StatusModule.win_nr, cfg.NS_ID)

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -62,7 +62,7 @@ function StatusModule._create_win()
       height = 3,
       row = vim.o.lines - vim.o.cmdheight - 1,
       col = vim.o.columns,
-      zindex = 10,
+      zindex = 50,
     })
     if api.nvim_win_set_hl_ns then
       api.nvim_win_set_hl_ns(StatusModule.win_nr, cfg.NS_ID)


### PR DESCRIPTION
The satellite.nvim plugin will create a window that spans a couple of
columns at the right-hand side of each window.
They use a [zindex of 40][zindex] for their windows.

Closes #7.

[zindex]: https://github.com/lewis6991/satellite.nvim/blob/25d0c59edab4892363c3cec47fc5f34769e5a242/lua/satellite/config.lua#L64
