### PR TITLE
Wrap long lines

### DIFF
--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -105,6 +105,29 @@ local function adjust_width(src, width)
    end
 end
 
+local function wrap_lines(content, width)
+   local message_blocks = vim.split(content, '\n', { plain = true, trimempty = true })
+
+   local message_lines = {}
+   for _, block in ipairs(message_blocks) do
+      if #block <= width then
+         table.insert(message_lines, block)
+      else
+         local len = #block
+         local start = 1
+         while len > 0 do
+            local line = string.sub(block, start, start + width - 1)
+            local trimmed = string.gsub(line, '^%s*(.-)%s*$', '%1')
+            table.insert(message_lines, trimmed)
+            start = start + width
+            len = len - width
+         end
+      end
+   end
+
+   return message_lines
+end
+
 StatusModule.redraw = scheduled(function()
    StatusModule._create_win()
 
@@ -117,13 +140,12 @@ StatusModule.redraw = scheduled(function()
 
 
    local function push_line(title, content)
-      local message_lines = vim.split(content.mandat, '\n', { plain = true, trimempty = true })
-
-
       local inner_width = width - (displayw(title) + 1)
       if content.icon then
          inner_width = inner_width - (displayw(content.icon) + 1)
       end
+
+      local message_lines = wrap_lines(content.mandat, inner_width)
 
       if cfg.config.debug then
          vim.pretty_print(message_lines)


### PR DESCRIPTION
Closes #11.

All the padding and formatting for multiple lines has already been written. I just had to write a function that splits lines into a table.

The result looks like that:
![image](https://user-images.githubusercontent.com/61948252/192154727-786f5dd8-eef0-43b2-84e8-665b46190056.png)

As you can see the function splits lines just by width. Splitting by words will be a bit trickier to implement but the general
idea will be the same. So I'd like to get some suggestions before I proceed.