### PR TITLE
feat: expose notify

### DIFF
--- a/lua/notifier/init.lua
+++ b/lua/notifier/init.lua
@@ -36,6 +36,9 @@ local commands = {
 }
 
 return {
+   notify = function(msg, level, opts)
+      notify(msg, level, opts)
+   end,
    setup = function(user_config)
       api.nvim_create_augroup(config.NS_NAME, {
          clear = true,

--- a/teal/notifier/init.tl
+++ b/teal/notifier/init.tl
@@ -36,6 +36,9 @@ local commands: {string:function()} = {
 }
 
 return {
+  notify = function(msg: string, level: integer, opts: NotifyOptions)
+      notify(msg, level, opts)
+  end,
   setup = function(user_config: config.Config)
     api.nvim_create_augroup(config.NS_NAME, {
       clear = true


### PR DESCRIPTION
Hi!

I would love to add **notifier.nvim** as a destination for routing messages from `ui_attach` with [Noice](https://github.com/folke/noice.nvim)

This PR simply exposes the `notify` function.