### PR TITLE
feat: level-aware content highlighting

### DIFF
--- a/lua/notifier/config.lua
+++ b/lua/notifier/config.lua
@@ -71,7 +71,14 @@ end
 
 
 ConfigModule.HL_CONTENT_DIM = hl_group("ContentDim", { link = "Comment", default = true })
-ConfigModule.HL_CONTENT = hl_group("Content", { link = "Normal", default = true })
+ConfigModule.HL_CONTENT = {
+   [vim.log.levels.TRACE] = hl_group("ContentTrace", { link = "Normal", default = true }),
+   [vim.log.levels.DEBUG] = hl_group("ContentDebug", { link = "Normal", default = true }),
+   [vim.log.levels.INFO] = hl_group("ContentInfo", { link = "Normal", default = true }),
+   [vim.log.levels.WARN] = hl_group("ContentWarn", { link = "WarningMsg", default = true }),
+   [vim.log.levels.ERROR] = hl_group("ContentError", { link = "ErrorMsg", default = true }),
+   [vim.log.levels.OFF] = hl_group("ContentOff", { link = "Normal", default = true }),
+}
 ConfigModule.HL_TITLE = hl_group("Title", { link = "Title", default = true })
 ConfigModule.HL_ICON = hl_group("Icon", { link = "Title", default = true })
 

--- a/lua/notifier/init.lua
+++ b/lua/notifier/init.lua
@@ -13,7 +13,7 @@ local function notify(msg, level, opts, no_cache)
    level = level or vim.log.levels.INFO
    opts = opts or {}
    if level >= config.config.notify.min_level then
-      status.push("nvim", { mandat = msg, title = opts.title, icon = opts.icon })
+      status.push("nvim", { mandat = msg, title = opts.title, icon = opts.icon, level = level })
       if not no_cache then
          table.insert(notify_msg_cache, { msg = msg, level = level, opts = opts })
       end

--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -12,6 +12,7 @@ local displayw = vim.fn.strdisplaywidth
 
 
 
+
 local StatusModule = {}
 
 
@@ -85,6 +86,7 @@ end
 local function adjust_width(src, width)
    return vim.fn["repeat"](" ", width - displayw(src)) .. src
 end
+
 
 
 
@@ -190,9 +192,9 @@ function StatusModule.redraw()
 
          table.insert(lines, formatted)
          if i == 1 then
-            table.insert(hl_infos, { name = title, dim = content.dim, icon = content.icon })
+            table.insert(hl_infos, { name = title, dim = content.dim, icon = content.icon, level = content.level })
          else
-            table.insert(hl_infos, { name = "", icon = "", dim = content.dim })
+            table.insert(hl_infos, { name = "", icon = "", dim = content.dim, level = content.level })
          end
       end
    end
@@ -229,7 +231,12 @@ function StatusModule.redraw()
          if hl_infos[i].dim then
             hl_group = cfg.HL_CONTENT_DIM
          else
-            hl_group = cfg.HL_CONTENT
+            local HL_CONTENT = cfg.HL_CONTENT
+            if type(HL_CONTENT) == "string" then
+               hl_group = HL_CONTENT
+            else
+               hl_group = HL_CONTENT[hl_infos[i].level]
+            end
          end
 
 
@@ -245,7 +252,7 @@ function StatusModule.redraw()
          else
             title_stop_offset = -1
          end
-         api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, hl_group, i - 1, 0, title_start_offset - 1)
+         api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, hl_group, i - 1, 0, title_start_offset + 1)
          api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, cfg.HL_TITLE, i - 1, title_start_offset, title_stop_offset)
 
          if hl_infos[i].icon then

--- a/teal/notifier/config.tl
+++ b/teal/notifier/config.tl
@@ -26,7 +26,7 @@ local record ConfigModule
 
   -- Highlight groups
   HL_CONTENT_DIM: string
-  HL_CONTENT: string
+  HL_CONTENT: string|{integer:string} 
   HL_TITLE: string
   HL_ICON: string
 end
@@ -71,7 +71,14 @@ end
 
 -- Global highlight definitions
 ConfigModule.HL_CONTENT_DIM = hl_group("ContentDim", { link = "Comment", default = true })
-ConfigModule.HL_CONTENT = hl_group("Content", { link = "Normal", default = true })
+ConfigModule.HL_CONTENT = {
+   [vim.log.levels.TRACE] = hl_group("ContentTrace", { link = "Normal", default = true }),
+   [vim.log.levels.DEBUG] = hl_group("ContentDebug", { link = "Normal", default = true }),
+   [vim.log.levels.INFO] = hl_group("ContentInfo", { link = "Normal", default = true }),
+   [vim.log.levels.WARN] = hl_group("ContentWarn", { link = "WarningMsg", default = true }),
+   [vim.log.levels.ERROR] = hl_group("ContentError", { link = "ErrorMsg", default = true }),
+   [vim.log.levels.OFF] = hl_group("ContentOff", { link = "Normal", default = true }),
+}
 ConfigModule.HL_TITLE = hl_group("Title", { link = "Title", default = true })
 ConfigModule.HL_ICON = hl_group("Icon", { link = "Title", default = true })
 

--- a/teal/notifier/init.tl
+++ b/teal/notifier/init.tl
@@ -13,7 +13,7 @@ local function notify(msg: string, level: integer, opts: NotifyOptions, no_cache
   level = level or vim.log.levels.INFO
   opts = opts or {}
   if level >= config.config.notify.min_level then
-    status.push("nvim", { mandat = msg, title = opts.title, icon = opts.icon })
+    status.push("nvim", { mandat = msg, title = opts.title, icon = opts.icon, level = level })
     if not no_cache then
       table.insert(notify_msg_cache,  { msg = msg, level = level, opts = opts })
     end

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -8,6 +8,7 @@ local record Message
   title: string|nil
   icon: string|nil
   opt: string|nil
+  level: integer
 end
 
 local type Component = {string|integer:Message}
@@ -90,6 +91,7 @@ local record HlInfo
   name: string
   icon: string
   dim: boolean
+  level: integer
 end
 
 function StatusModule.redraw()
@@ -154,7 +156,7 @@ function StatusModule.redraw()
     for i,line in ipairs(message_lines) do
       -- This is where we handle multiline notifications
 
-      -- For a given line, the amount of space to be left-alligned in the message
+      -- For a given line, the amount of space to be left-aligned in the message
       local right_pad_len = maxlen - displayw(line)
 
       -- Try to render optional message part and see if it fits
@@ -187,12 +189,12 @@ function StatusModule.redraw()
         vim.pretty_print(formatted)
       end
 
-      -- TODO(vigoux): right allign multiline messages instead of push like this
+      -- TODO(vigoux): right align multiline messages instead of push like this
       table.insert(lines, formatted)
       if i == 1 then
-        table.insert(hl_infos, { name = title, dim = content.dim, icon = content.icon })
+        table.insert(hl_infos, { name = title, dim = content.dim, icon = content.icon, level = content.level })
       else
-        table.insert(hl_infos, { name = "", icon = "", dim = content.dim })
+        table.insert(hl_infos, { name = "", icon = "", dim = content.dim , level = content.level })
       end
     end
   end
@@ -229,7 +231,12 @@ function StatusModule.redraw()
       if hl_infos[i].dim then
         hl_group = cfg.HL_CONTENT_DIM
       else
-        hl_group = cfg.HL_CONTENT
+        local HL_CONTENT = cfg.HL_CONTENT
+        if HL_CONTENT is string then
+          hl_group = HL_CONTENT
+        else
+          hl_group = HL_CONTENT[hl_infos[i].level]
+        end
       end
 
       -- Here the highlighting is done in byte indexes, so we have to correct the byte offset
@@ -245,7 +252,7 @@ function StatusModule.redraw()
       else
         title_stop_offset = -1
       end
-      api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, hl_group, i - 1, 0, title_start_offset - 1)
+      api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, hl_group, i - 1, 0, title_start_offset + 1)
       api.nvim_buf_add_highlight(StatusModule.buf_nr, cfg.NS_ID, cfg.HL_TITLE, i - 1, title_start_offset, title_stop_offset)
 
       if hl_infos[i].icon then


### PR DESCRIPTION
I've been running a feature branch for a while now where this is one of the
added features. Figured it'd be really nice to be able to discern the severity
of a log item from its log level. This is a breaking change in terms of the
configuration schema where HL_CONTENT now is a table instead of a string.

![Screenshot 2022-12-01 at 15 27 40](https://user-images.githubusercontent.com/6705160/205079413-c2710236-236c-4e5d-a7c9-2fe7e2b4c00a.png)

