### PR TITLE
Update deprecated function 'tbl_islist' to 'islist'

### DIFF
--- a/lua/notifier/status.lua
+++ b/lua/notifier/status.lua
@@ -196,7 +196,7 @@ function StatusModule.redraw()
 
    for _, compname in ipairs(cfg.config.components) do
       local msgs = StatusModule.active[compname] or {}
-      local is_tbl = vim.tbl_islist(msgs)
+      local is_tbl = vim.islist(msgs)
 
       for name, msg in pairs(msgs) do
 

--- a/teal/notifier/status.tl
+++ b/teal/notifier/status.tl
@@ -196,7 +196,7 @@ function StatusModule.redraw()
   -- For each component, print the messages
   for _, compname in ipairs(cfg.config.components) do
     local msgs = StatusModule.active[compname] or {}
-    local is_tbl = vim.tbl_islist(msgs)
+    local is_tbl = vim.islist(msgs)
 
     for name, msg in pairs(msgs) do
       -- Resolve notification name

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -179,7 +179,7 @@ global record vim
 
   tbl_contains: function<T>({T}, T): boolean
   tbl_deep_extend: function(string, ...: table): table
-  tbl_islist: function({any:any}): boolean
+  islist: function({any:any}): boolean
 
   pretty_print: function(any)
 


### PR DESCRIPTION
Changed [vim.tbl_islist](https://neovim.io/doc/user/deprecated.html#vim.tbl_islist()) to [vim.islist](https://neovim.io/doc/user/lua.html#vim.islist()) to fix the deprecated warnings.